### PR TITLE
Add Redis lettuce config and user example

### DIFF
--- a/src/main/kotlin/org/study/springredisstudy/redis/RedisConfigration.kt
+++ b/src/main/kotlin/org/study/springredisstudy/redis/RedisConfigration.kt
@@ -1,0 +1,17 @@
+package org.study.springredisstudy.redis
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@Configuration
+class RedisConfigration {
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory()
+
+    @Bean
+    fun stringRedisTemplate(connectionFactory: RedisConnectionFactory): StringRedisTemplate =
+        StringRedisTemplate(connectionFactory)
+}

--- a/src/main/kotlin/org/study/springredisstudy/redis/RedisController.kt
+++ b/src/main/kotlin/org/study/springredisstudy/redis/RedisController.kt
@@ -1,10 +1,6 @@
 package org.study.springredisstudy.redis
 
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class RedisController(private val redisService: RedisService) {
@@ -15,4 +11,12 @@ class RedisController(private val redisService: RedisService) {
 
     @GetMapping("/redis/{key}")
     fun get(@PathVariable key: String): String? = redisService.getValue(key)
+
+    @PostMapping("/redis/user/{id}")
+    fun saveUser(@PathVariable id: String, @RequestParam name: String) {
+        redisService.saveUser(User(id, name))
+    }
+
+    @GetMapping("/redis/user/{id}")
+    fun getUser(@PathVariable id: String): User? = redisService.getUser(id)
 }

--- a/src/main/kotlin/org/study/springredisstudy/redis/RedisRepository.kt
+++ b/src/main/kotlin/org/study/springredisstudy/redis/RedisRepository.kt
@@ -3,11 +3,62 @@ package org.study.springredisstudy.redis
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Repository
 
+/**
+ * Repository exposing basic Redis operations using Lettuce.
+ */
 @Repository
 class RedisRepository(private val redisTemplate: StringRedisTemplate) {
+
+    /* Value operations */
     fun set(key: String, value: String) {
         redisTemplate.opsForValue().set(key, value)
     }
 
     fun get(key: String): String? = redisTemplate.opsForValue().get(key)
+
+    /* Hash operations */
+    fun putHash(key: String, hashKey: String, value: String) {
+        redisTemplate.opsForHash<String, String>().put(key, hashKey, value)
+    }
+
+    fun getHash(key: String, hashKey: String): String? =
+        redisTemplate.opsForHash<String, String>()[key, hashKey]
+
+    /* List operations */
+    fun leftPush(key: String, value: String) {
+        redisTemplate.opsForList().leftPush(key, value)
+    }
+
+    fun rangeList(key: String, start: Long, end: Long): List<String> =
+        redisTemplate.opsForList().range(key, start, end) ?: emptyList()
+
+    /* Set operations */
+    fun addSet(key: String, value: String) {
+        redisTemplate.opsForSet().add(key, value)
+    }
+
+    fun members(key: String): Set<String> = redisTemplate.opsForSet().members(key) ?: emptySet()
+
+    /* ZSet operations */
+    fun addZSet(key: String, value: String, score: Double) {
+        redisTemplate.opsForZSet().add(key, value, score)
+    }
+
+    fun rangeZSet(key: String, start: Long, end: Long): Set<String> =
+        redisTemplate.opsForZSet().range(key, start, end) ?: emptySet()
+
+    /* User operations */
+    fun saveUser(user: User) {
+        val key = "user:${'$'}{user.id}"
+        redisTemplate.opsForHash<String, String>().put(key, "id", user.id)
+        redisTemplate.opsForHash<String, String>().put(key, "name", user.name)
+    }
+
+    fun findUser(id: String): User? {
+        val key = "user:${'$'}id"
+        val map = redisTemplate.opsForHash<String, String>().entries(key)
+        val userId = map["id"]
+        val name = map["name"]
+        return if (userId != null && name != null) User(userId, name) else null
+    }
 }

--- a/src/main/kotlin/org/study/springredisstudy/redis/RedisService.kt
+++ b/src/main/kotlin/org/study/springredisstudy/redis/RedisService.kt
@@ -7,4 +7,29 @@ class RedisService(private val redisRepository: RedisRepository) {
     fun setValue(key: String, value: String) = redisRepository.set(key, value)
 
     fun getValue(key: String): String? = redisRepository.get(key)
+
+    fun putHash(key: String, hashKey: String, value: String) =
+        redisRepository.putHash(key, hashKey, value)
+
+    fun getHash(key: String, hashKey: String): String? =
+        redisRepository.getHash(key, hashKey)
+
+    fun leftPush(key: String, value: String) = redisRepository.leftPush(key, value)
+
+    fun rangeList(key: String, start: Long, end: Long): List<String> =
+        redisRepository.rangeList(key, start, end)
+
+    fun addSet(key: String, value: String) = redisRepository.addSet(key, value)
+
+    fun members(key: String): Set<String> = redisRepository.members(key)
+
+    fun addZSet(key: String, value: String, score: Double) =
+        redisRepository.addZSet(key, value, score)
+
+    fun rangeZSet(key: String, start: Long, end: Long): Set<String> =
+        redisRepository.rangeZSet(key, start, end)
+
+    fun saveUser(user: User) = redisRepository.saveUser(user)
+
+    fun getUser(id: String): User? = redisRepository.findUser(id)
 }

--- a/src/main/kotlin/org/study/springredisstudy/redis/User.kt
+++ b/src/main/kotlin/org/study/springredisstudy/redis/User.kt
@@ -1,0 +1,3 @@
+package org.study.springredisstudy.redis
+
+data class User(val id: String, val name: String)

--- a/src/test/kotlin/org/study/springredisstudy/RedisServiceTest.kt
+++ b/src/test/kotlin/org/study/springredisstudy/RedisServiceTest.kt
@@ -1,0 +1,29 @@
+package org.study.springredisstudy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.study.springredisstudy.redis.RedisRepository
+import org.study.springredisstudy.redis.RedisService
+import org.study.springredisstudy.redis.User
+
+class RedisServiceTest {
+
+    private val repository: RedisRepository = mock(RedisRepository::class.java)
+    private val service = RedisService(repository)
+
+    @Test
+    fun saveAndRetrieveUser() {
+        val user = User("1", "Alice")
+        `when`(repository.findUser("1")).thenReturn(user)
+
+        service.saveUser(user)
+        verify(repository).saveUser(user)
+
+        val result = service.getUser("1")
+        verify(repository).findUser("1")
+        assertEquals(user, result)
+    }
+}


### PR DESCRIPTION
## Summary
- add `RedisConfigration` to configure lettuce connection
- add `User` data class and user APIs
- expand repository/service with examples of value/hash/list/set/zset operations
- add controller endpoints for user
- include unit test for `RedisService`

## Testing
- `./gradlew test` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68879221da74832e8cf506f583ffeed5