### PR TITLE
Add Redis Lettuce config and repository with tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
+    testImplementation 'it.ozimov:embedded-redis:0.7.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/kotlin/org/study/Application.kt
+++ b/src/main/kotlin/org/study/Application.kt
@@ -1,0 +1,11 @@
+package org.study
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}

--- a/src/main/kotlin/org/study/config/RedisConfiguration.kt
+++ b/src/main/kotlin/org/study/config/RedisConfiguration.kt
@@ -1,0 +1,40 @@
+package org.study.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import org.study.user.User
+
+@Configuration
+class RedisConfiguration {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory =
+        LettuceConnectionFactory()
+
+    @Bean
+    fun redisTemplate(
+        connectionFactory: RedisConnectionFactory,
+        objectMapper: ObjectMapper
+    ): RedisTemplate<String, User> {
+        val template = RedisTemplate<String, User>()
+        template.setConnectionFactory(connectionFactory)
+
+        val keySerializer = StringRedisSerializer()
+        val valueSerializer = Jackson2JsonRedisSerializer(User::class.java).apply {
+            setObjectMapper(objectMapper)
+        }
+
+        template.keySerializer = keySerializer
+        template.hashKeySerializer = keySerializer
+        template.valueSerializer = valueSerializer
+        template.hashValueSerializer = valueSerializer
+        template.afterPropertiesSet()
+        return template
+    }
+}

--- a/src/main/kotlin/org/study/user/User.kt
+++ b/src/main/kotlin/org/study/user/User.kt
@@ -1,0 +1,6 @@
+package org.study.user
+
+data class User(
+    val id: String,
+    val name: String
+)

--- a/src/main/kotlin/org/study/user/UserRepository.kt
+++ b/src/main/kotlin/org/study/user/UserRepository.kt
@@ -1,0 +1,40 @@
+package org.study.user
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Duration
+
+@Repository
+class UserRepository(
+    private val redisTemplate: RedisTemplate<String, User>
+) {
+    private val valueOps = redisTemplate.opsForValue()
+
+    fun save(user: User) {
+        valueOps.set(user.id, user)
+    }
+
+    fun saveIfAbsent(user: User): Boolean {
+        return valueOps.setIfAbsent(user.id, user) ?: false
+    }
+
+    fun find(id: String): User? = valueOps.get(id)
+
+    fun exists(id: String): Boolean = redisTemplate.hasKey(id)
+
+    fun delete(id: String) {
+        redisTemplate.delete(id)
+    }
+
+    fun expire(id: String, ttl: Duration): Boolean {
+        return redisTemplate.expire(id, ttl)
+    }
+
+    fun incrementCounter(key: String): Long? {
+        return redisTemplate.opsForValue().increment(key)
+    }
+
+    fun decrementCounter(key: String): Long? {
+        return redisTemplate.opsForValue().decrement(key)
+    }
+}

--- a/src/test/kotlin/org/study/user/UserRepositoryTest.kt
+++ b/src/test/kotlin/org/study/user/UserRepositoryTest.kt
@@ -1,0 +1,54 @@
+package org.study.user
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import redis.embedded.RedisServer
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UserRepositoryTest {
+
+    private lateinit var redisServer: RedisServer
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @BeforeAll
+    fun startRedis() {
+        redisServer = RedisServer()
+        redisServer.start()
+    }
+
+    @AfterAll
+    fun stopRedis() {
+        redisServer.stop()
+    }
+
+    @Test
+    fun `save and find user`() {
+        val user = User("1", "tester")
+        userRepository.save(user)
+        val result = userRepository.find("1")
+        Assertions.assertEquals(user, result)
+    }
+
+    @Test
+    fun `exists and delete`() {
+        val user = User("2", "remove")
+        userRepository.save(user)
+        Assertions.assertTrue(userRepository.exists("2"))
+        userRepository.delete("2")
+        Assertions.assertFalse(userRepository.exists("2"))
+    }
+
+    @Test
+    fun `increment and decrement counter`() {
+        Assertions.assertEquals(1, userRepository.incrementCounter("count"))
+        Assertions.assertEquals(0, userRepository.decrementCounter("count"))
+    }
+}


### PR DESCRIPTION
## Summary
- configure Lettuce-based RedisTemplate in `RedisConfiguration`
- implement simple `User` entity and `UserRepository`
- provide Spring Boot application entry point
- add tests using embedded Redis
- include embedded-redis dependency for tests

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68879221da74832e8cf506f583ffeed5